### PR TITLE
Add customer-facing landing page for photo and video services

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -19,6 +19,7 @@ import { AgregarPersonalComponent } from './control-panel/gestionar-personal/agr
 import { ListarportipoComponent } from './control-panel/administrar-equipos/listarportipo/listarportipo.component';
 import { ValidarTokenGuard } from './guards/validar-token.guard';
 import { VerCalendarioComponent } from './control-panel/ver-calendario/ver-calendario.component';
+import { LandingComponent } from './landing/landing.component';
 /* 
 const routes: Routes = [
   {
@@ -35,7 +36,8 @@ const routes: Routes = [
   }
 ]; */
 const routes: Routes = [
-  { path: '', pathMatch: 'full', redirectTo: 'auth' },   // 👈 añade esto
+  { path: '', component: LandingComponent },
+  { path: 'inicio', component: LandingComponent },
   {
     path: 'auth',
     loadChildren: () => import('./auth/auth.module').then(m => m.AuthModule)
@@ -46,7 +48,7 @@ const routes: Routes = [
     // canActivate: [ValidarTokenGuard],
     // canLoad: [ValidarTokenGuard],
   },
-  { path: '**', redirectTo: 'auth' }
+  { path: '**', redirectTo: '' }
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -60,6 +60,7 @@ import { FullCalendarModule } from '@fullcalendar/angular'; // must go before pl
 import dayGridPlugin from '@fullcalendar/daygrid'; // a plugin!
 import interactionPlugin  from '@fullcalendar/interaction';
 import { DialogComponent } from './control-panel/ver-calendario/dialog/dialog.component'; // a plugin!
+import { LandingComponent } from './landing/landing.component';
 
 
 
@@ -99,6 +100,7 @@ import { DialogComponent } from './control-panel/ver-calendario/dialog/dialog.co
         DetallesAlquiladoComponent,
         VerCalendarioComponent,
         DialogComponent,
+        LandingComponent,
     ],
     bootstrap: [AppComponent], imports: [BrowserModule,
         FormsModule,

--- a/src/app/landing/landing.component.css
+++ b/src/app/landing/landing.component.css
@@ -1,0 +1,332 @@
+:host {
+  display: block;
+  color: #1a1a1a;
+  font-family: 'Poppins', 'Helvetica Neue', Arial, sans-serif;
+  background: #ffffff;
+}
+
+section {
+  padding: 4rem 1.5rem;
+}
+
+.hero {
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  padding: 6rem 1.5rem 4rem;
+  background: linear-gradient(135deg, #101828 0%, #312e81 100%);
+  color: #f8fafc;
+}
+
+.hero__content {
+  max-width: 520px;
+}
+
+.hero__subtitle {
+  font-size: 0.95rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin-bottom: 1rem;
+  color: rgba(248, 250, 252, 0.8);
+}
+
+.hero__title {
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  line-height: 1.1;
+  margin-bottom: 1.5rem;
+  font-weight: 700;
+}
+
+.hero__description {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  margin-bottom: 2rem;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.hero__image {
+  width: 100%;
+  min-height: 320px;
+  border-radius: 28px;
+  background: linear-gradient(
+      rgba(15, 23, 42, 0.45),
+      rgba(15, 23, 42, 0.7)
+    ),
+    url('https://images.unsplash.com/photo-1526170375885-4d8ecf77b99f?auto=format&fit=crop&w=1200&q=80') center/cover;
+  box-shadow: 0 35px 60px -20px rgba(15, 23, 42, 0.6);
+}
+
+.section-title {
+  font-size: clamp(2rem, 3.5vw, 2.6rem);
+  text-align: center;
+  margin-bottom: 2.5rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.section-title--light {
+  color: #f8fafc;
+}
+
+.features {
+  background: #f8fafc;
+}
+
+.features__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  padding: 1.8rem;
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+}
+
+.card h3 {
+  font-size: 1.3rem;
+  margin-bottom: 0.75rem;
+  color: #1f2937;
+}
+
+.card p {
+  color: #475569;
+  line-height: 1.6;
+}
+
+.portfolio {
+  background: linear-gradient(135deg, #0f172a, #1e293b);
+  color: #f8fafc;
+  display: grid;
+  place-items: center;
+  text-align: center;
+}
+
+.portfolio__content {
+  max-width: 700px;
+}
+
+.portfolio__list {
+  list-style: none;
+  padding: 0;
+  margin-top: 2rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.portfolio__list li {
+  padding: 0.9rem 1.2rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.packages {
+  background: #f8fafc;
+}
+
+.packages__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.package {
+  padding: 2.2rem 1.8rem;
+  border-radius: 22px;
+  background: #ffffff;
+  text-align: center;
+  border: 2px solid transparent;
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.package--featured {
+  border-color: #4f46e5;
+  transform: translateY(-4px);
+  box-shadow: 0 25px 45px rgba(79, 70, 229, 0.25);
+}
+
+.package h3 {
+  font-size: 1.4rem;
+  margin-bottom: 1rem;
+  color: #1e1b4b;
+}
+
+.package__description {
+  color: #4b5563;
+  line-height: 1.6;
+  min-height: 84px;
+}
+
+.package__price {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 1.5rem 0;
+  color: #312e81;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.95rem 1.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, #6366f1, #4338ca);
+  color: #ffffff;
+  box-shadow: 0 12px 30px rgba(67, 56, 202, 0.35);
+}
+
+.btn--outline {
+  border: 2px solid rgba(248, 250, 252, 0.65);
+  color: #f8fafc;
+  background: transparent;
+}
+
+.btn--light {
+  background: #ffffff;
+  color: #1e1b4b;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.2);
+}
+
+.btn:hover {
+  transform: translateY(-3px);
+}
+
+.btn--block {
+  width: 100%;
+}
+
+.testimonials {
+  background: #ffffff;
+}
+
+.testimonials__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.testimonial {
+  padding: 1.8rem;
+  border-radius: 18px;
+  background: #f1f5f9;
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.35);
+}
+
+.testimonial__quote {
+  font-style: italic;
+  line-height: 1.6;
+  color: #1f2937;
+}
+
+.testimonial__author {
+  margin-top: 1.2rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.testimonial__role {
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.cta {
+  padding: 3.5rem 1.5rem;
+  margin: 4rem 1.5rem;
+  border-radius: 26px;
+  background: linear-gradient(135deg, #4338ca, #7c3aed);
+  color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.cta__content {
+  max-width: 540px;
+}
+
+.cta h2 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin-bottom: 1rem;
+}
+
+.footer {
+  padding: 2.5rem 1.5rem 3rem;
+  background: #0f172a;
+  color: rgba(248, 250, 252, 0.8);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: center;
+  text-align: center;
+}
+
+.footer__brand {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.footer__nav {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.footer__nav a {
+  color: rgba(248, 250, 252, 0.8);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.footer__nav a:hover {
+  color: #ffffff;
+}
+
+@media (min-width: 992px) {
+  section {
+    padding: 5rem 3rem;
+  }
+
+  .hero {
+    padding: 7rem 4rem 5rem;
+  }
+
+  .cta {
+    margin: 5rem auto;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 3.5rem 3.5rem;
+    max-width: 1080px;
+  }
+
+  .cta__content {
+    margin-right: 2rem;
+  }
+}

--- a/src/app/landing/landing.component.html
+++ b/src/app/landing/landing.component.html
@@ -1,0 +1,101 @@
+<section class="hero">
+  <div class="hero__content">
+    <p class="hero__subtitle">Fotografía y video profesional</p>
+    <h1 class="hero__title">Capturamos tu historia con emoción y detalle</h1>
+    <p class="hero__description">
+      Somos un equipo creativo especializado en eventos sociales y corporativos. Creamos experiencias visuales
+      memorables para que revivas tus momentos más importantes.
+    </p>
+    <div class="hero__actions">
+      <a routerLink="/auth" class="btn btn--primary">Reserva tu sesión</a>
+      <a href="#portafolio" class="btn btn--outline">Ver portafolio</a>
+    </div>
+  </div>
+  <div class="hero__image" role="presentation" aria-hidden="true"></div>
+</section>
+
+<section class="features" id="servicios">
+  <h2 class="section-title">Soluciones para cada momento</h2>
+  <div class="features__grid">
+    <article class="card">
+      <h3>Bodas &amp; compromisos</h3>
+      <p>Planificación personalizada, cobertura completa y narrativas visuales llenas de emoción.</p>
+    </article>
+    <article class="card">
+      <h3>Eventos corporativos</h3>
+      <p>Contenido audiovisual estratégico para lanzar productos, documentar conferencias y humanizar tu marca.</p>
+    </article>
+    <article class="card">
+      <h3>Sesiones familiares</h3>
+      <p>Fotografía lifestyle, newborn y retratos que destacan la esencia de cada familia.</p>
+    </article>
+    <article class="card">
+      <h3>Producción para redes</h3>
+      <p>Videos verticales, reels y fotografías optimizadas para impactar en plataformas digitales.</p>
+    </article>
+  </div>
+</section>
+
+<section class="portfolio" id="portafolio">
+  <div class="portfolio__content">
+    <h2 class="section-title section-title--light">Historias que inspiran</h2>
+    <p>
+      Trabajamos con equipos de alta gama y una dirección creativa enfocada en contar historias auténticas.
+      Descubre algunos de nuestros proyectos favoritos:
+    </p>
+    <ul class="portfolio__list">
+      <li>Video documental de boda - Vanessa &amp; Diego</li>
+      <li>Cobertura audiovisual para congreso tecnológico 2023</li>
+      <li>Campaña fotográfica para marca de moda sostenible</li>
+      <li>Sesión lifestyle familiar - Los Mendoza</li>
+    </ul>
+  </div>
+</section>
+
+<section class="packages" id="paquetes">
+  <h2 class="section-title">Paquetes diseñados para ti</h2>
+  <div class="packages__grid">
+    <article class="package" *ngFor="let pkg of packages" [class.package--featured]="pkg.featured">
+      <h3>{{ pkg.name }}</h3>
+      <p class="package__description">{{ pkg.description }}</p>
+      <p class="package__price">{{ pkg.price }}</p>
+      <a routerLink="/auth" class="btn btn--primary btn--block">Solicitar cotización</a>
+    </article>
+  </div>
+</section>
+
+<section class="testimonials" id="testimonios">
+  <h2 class="section-title">Lo que dicen nuestros clientes</h2>
+  <div class="testimonials__grid">
+    <article class="testimonial" *ngFor="let testimonial of testimonials">
+      <p class="testimonial__quote">“{{ testimonial.quote }}”</p>
+      <p class="testimonial__author">{{ testimonial.name }}</p>
+      <p class="testimonial__role">{{ testimonial.role }}</p>
+    </article>
+  </div>
+</section>
+
+<section class="cta" id="contacto">
+  <div class="cta__content">
+    <h2>¿Listo para contar tu historia?</h2>
+    <p>
+      Agenda una videollamada gratuita y juntos diseñaremos la producción que necesitas. Atendemos en todo el Perú y
+      contamos con disponibilidad para proyectos internacionales.
+    </p>
+  </div>
+  <a routerLink="/auth" class="btn btn--light">Agendar ahora</a>
+</section>
+
+<footer class="footer">
+  <div>
+    <p class="footer__brand">© {{ currentYear }} Memoriza Films</p>
+    <p>Fotografía y video profesional para momentos inolvidables.</p>
+  </div>
+  <nav class="footer__nav" aria-label="Enlaces rápidos">
+    <a href="#servicios">Servicios</a>
+    <a href="#portafolio">Portafolio</a>
+    <a href="#paquetes">Paquetes</a>
+    <a href="#testimonios">Testimonios</a>
+    <a href="#contacto">Contacto</a>
+  </nav>
+</footer>

--- a/src/app/landing/landing.component.ts
+++ b/src/app/landing/landing.component.ts
@@ -1,0 +1,52 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-landing',
+  templateUrl: './landing.component.html',
+  styleUrls: ['./landing.component.css'],
+})
+export class LandingComponent {
+  public currentYear = new Date().getFullYear();
+
+  public testimonials = [
+    {
+      name: 'María & José',
+      role: 'Boda en Cusco',
+      quote:
+        'Capturaron cada momento mágico con una calidad impresionante. ¡Revivo mi boda cada vez que veo el video!',
+    },
+    {
+      name: 'Grupo Andante',
+      role: 'Sesión corporativa',
+      quote:
+        'El equipo logró transmitir la esencia de nuestra marca. Fotografías impecables y un servicio muy profesional.',
+    },
+    {
+      name: 'Lucía Torres',
+      role: 'Cumpleaños de 15',
+      quote:
+        'El video resumen fue emocionante y auténtico. Nos guiaron con creatividad en cada toma.',
+    },
+  ];
+
+  public packages = [
+    {
+      name: 'Recuerdos Esenciales',
+      description: 'Cobertura fotográfica de hasta 4 horas, entrega digital y galería privada.',
+      price: 'S/ 890',
+    },
+    {
+      name: 'Historia Completa',
+      description:
+        'Cobertura de foto y video durante todo el evento, video highlight de 3 minutos y álbum profesional.',
+      price: 'S/ 1,690',
+      featured: true,
+    },
+    {
+      name: 'Experiencia Premium',
+      description:
+        'Equipo de dos fotógrafos y un videógrafo, drone, entrega express y libro fotográfico de lujo.',
+      price: 'S/ 2,450',
+    },
+  ];
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,10 +1,13 @@
 /* You can add global styles to this file, and also import other style files */
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
 
 html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
-
-html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+body {
+  margin: 0;
+  font-family: 'Poppins', Roboto, 'Helvetica Neue', sans-serif;
+  background-color: #f5f7fb;
+  color: #1a1a1a;
+}
 
 span.mat-radio-inner-circle {
     background-color: #304a6e !important;


### PR DESCRIPTION
## Summary
- add a new landing component that showcases hero messaging, services, packages, testimonials, and a CTA tailored to the photo and video offering
- expose the landing component on the root and `/inicio` routes while keeping existing auth and dashboard routes intact
- refresh global typography with the Poppins font to complement the marketing design

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d969731c688333b262cee980da8bea