### PR TITLE
Remove unused FullCalendar timegrid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@fullcalendar/core": "^6.1.19",
     "@fullcalendar/daygrid": "^6.1.19",
     "@fullcalendar/interaction": "^6.1.19",
-    "@fullcalendar/timegrid": "^6.1.19",
     "@ng-bootstrap/ng-bootstrap": "^17.0.1",
     "@popperjs/core": "^2.11.8",
     "@swimlane/ngx-charts": "^20.5.0",


### PR DESCRIPTION
## Summary
- remove the @fullcalendar/timegrid package from the application's dependencies

## Testing
- CI=true timeout 120s npx ng serve --host 0.0.0.0 --port 4200 (terminated after confirming successful compile)


------
https://chatgpt.com/codex/tasks/task_e_68da4ae4280083339e6df3ed6e77e38a