### PR TITLE
Remove ngx-echarts integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "@swimlane/ngx-charts": "^20.5.0",
     "bootstrap": "^5.3.8",
     "d3": "^7.9.0",
-    "echarts": "^5.2.2",
-    "ngx-echarts": "^8.0.1",
     "pdfmake": "^0.2.2",
     "rxjs": "~7.8",
     "sweetalert2": "^11.22.5",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,7 +18,6 @@ import { MatPaginatorIntl } from '@angular/material/paginator';
 import { getSpanishPaginatorIntl } from './shared/angular-material/spanish-paginator-intl';
 import { ReactiveFormsModule } from '@angular/forms';
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
-import { NgxEchartsModule } from 'ngx-echarts';
 
 
 // import {
@@ -112,9 +111,7 @@ import { LandingComponent } from './landing/landing.component';
         // NgxMatNativeDateModule,
         ReactiveFormsModule,
         NgbModule,
-        NgxChartsModule, NgxEchartsModule.forRoot({
-            echarts: () => import('echarts')
-        }),
+        NgxChartsModule,
         FullCalendarModule], providers: [
         { provide: MatPaginatorIntl, useValue: getSpanishPaginatorIntl() },
         DatePipe,


### PR DESCRIPTION
## Summary
- remove the unused `echarts` and `ngx-echarts` dependencies now that charts rely on `@swimlane/ngx-charts`
- drop the `NgxEchartsModule` import and registration from `AppModule`

## Testing
- npm install
- CI=1 npx ng serve --host=0.0.0.0 --port=4200 --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68da4fc549cc8333885ece097cf3d118