### PR TITLE
Remove clone-deep from Angular CommonJS allow list

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -25,9 +25,6 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
-            "allowedCommonJsDependencies": [
-              "clone-deep"
-            ],
             "assets": [
               "src/favicon.ico",
               "src/assets"

--- a/angular.json.bak
+++ b/angular.json.bak
@@ -25,9 +25,6 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
-            "allowedCommonJsDependencies": [
-              "clone-deep"
-            ],
             "assets": [
               "src/favicon.ico",
               "src/assets"


### PR DESCRIPTION
## Summary
- remove the clone-deep package from the allowedCommonJsDependencies list in angular.json and the backup copy

## Testing
- CI=true npx ng build --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68da5512cd008333ab628518502b1012