### PR TITLE
chore: allow pdfmake CommonJS dependencies

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -34,7 +34,11 @@
               "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
               "src/styles.css"
             ],
-            "scripts": []
+            "scripts": [],
+            "allowedCommonJsDependencies": [
+              "pdfmake/build/pdfmake",
+              "pdfmake/build/vfs_fonts"
+            ]
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
## Summary
- allow pdfmake and its bundled fonts in the Angular CLI commonjs allowlist to prevent build warnings

## Testing
- npx ng build --progress=false --configuration production

------
https://chatgpt.com/codex/tasks/task_e_68da56de5db4833395252e6f4336b17c