### PR TITLE
Align cliente management headers and shared styles

### DIFF
--- a/src/app/control-panel/gestionar-cliente/clientes-common.css
+++ b/src/app/control-panel/gestionar-cliente/clientes-common.css
@@ -1,0 +1,22 @@
+.dashboard-content {
+  padding: 2rem 0;
+}
+
+.dashboard-content h1 {
+  font-size: 40px;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+}
+
+.dashboard-content .card {
+  margin-bottom: 1.5rem;
+}
+
+.dashboard-content .btn {
+  min-width: 120px;
+}
+
+.button-margin {
+  margin-bottom: 20px;
+  float: right;
+}

--- a/src/app/control-panel/gestionar-cliente/editar-cliente/editar-cliente.component.html
+++ b/src/app/control-panel/gestionar-cliente/editar-cliente/editar-cliente.component.html
@@ -1,69 +1,60 @@
-<div class="container-fluid dashboard-content ">
-    <div class="row">
-        <div class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12">
-            <div class="page-header">
-                <h2 class="pageheader-title">Form Validations </h2>
-                <p class="pageheader-text">Proin placerat ante duiullam scelerisque a velit ac porta, fusce sit amet vestibulum mi. Morbi lobortis pulvinar quam.</p>
-                <div class="page-breadcrumb">
-                    <nav aria-label="breadcrumb">
-                        <ol class="breadcrumb">
-                            <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Dashboard</a></li>
-                            <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Forms</a></li>
-                            <li class="breadcrumb-item active" aria-current="page">Form Validations</li>
-                        </ol>
-                    </nav>
-                </div>
-            </div>
-        </div>
-    </div>
+<div class="dashboard-ecommerce">
+  <div class="container-fluid dashboard-content">
+    <h1 class="mb-4">Clientes</h1>
 
     <form #clienteEditarForm="ngForm" (ngSubmit)="editCliente(clienteEditarForm)">
-        <!-- card numero 1 -->
-        <mat-card class="card">
-            <mat-card-header class="card-header">
-                <mat-card-title>Editar Cliente</mat-card-title>
-            </mat-card-header>
-            <mat-card-content class="card-body">
-                <div class="form-row">
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 input-disabled" appearance="fill">
-                        <mat-label>codigoCliente</mat-label>
-                        <input matInput type="text" name="codigoCliente" #codigoCliente="ngModel" [(ngModel)]="service.selectCliente.codigoCliente" [readonly]="true">
-                    </mat-form-field>
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Nombre</mat-label>
-                        <input matInput type="text" name="nombre" #nombre="ngModel" [(ngModel)]="service.selectCliente.nombre" disabled required>
-                    </mat-form-field>
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Apellido</mat-label>
-                        <input matInput type="text" name="apellido" #apellido="ngModel" [(ngModel)]="service.selectCliente.apellido" disabled required>
-                    </mat-form-field>
+      <mat-card class="card">
+        <mat-card-header class="card-header">
+          <mat-card-title>Editar Cliente</mat-card-title>
+        </mat-card-header>
+        <mat-card-content class="card-body">
+          <div class="form-row">
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 input-disabled" appearance="fill">
+              <mat-label>codigoCliente</mat-label>
+              <input matInput type="text" name="codigoCliente" #codigoCliente="ngModel"
+                [(ngModel)]="service.selectCliente.codigoCliente" [readonly]="true">
+            </mat-form-field>
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Nombre</mat-label>
+              <input matInput type="text" name="nombre" #nombre="ngModel" [(ngModel)]="service.selectCliente.nombre" disabled
+                required>
+            </mat-form-field>
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Apellido</mat-label>
+              <input matInput type="text" name="apellido" #apellido="ngModel"
+                [(ngModel)]="service.selectCliente.apellido" disabled required>
+            </mat-form-field>
 
-                    <mat-form-field appearance="fill" class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2">
-                        <mat-label>Correo</mat-label>
-                        <input matInput type="text" name="correo" #correo="ngModel" [(ngModel)]="service.selectCliente.correo" [pattern]="correoPattern" required>
-                    </mat-form-field>
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Número de documento</mat-label>
-                        <input matInput type="text" name="doc" #doc="ngModel" [(ngModel)]="service.selectCliente.doc" disabled required>
-                    </mat-form-field>
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Celular</mat-label>
-                        <input matInput type="text" name="celular" #celular="ngModel" [(ngModel)]="service.selectCliente.celular" [pattern]="celularPattern" required>
-                    </mat-form-field>
-                </div>
-                <div class="form-row">
-                    <mat-form-field class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12 mb-12 " appearance="fill">
-                        <mat-label>Dirección</mat-label>
-                        <textarea matInput type="text" name="direccion" #direccion="ngModel" [(ngModel)]="service.selectCliente.direccion" required></textarea>
-                    </mat-form-field>
-                </div>
-            </mat-card-content>
-        </mat-card>
-        <button class="btn btn-primary mb-2 mr-1" type="submit" [disabled]="clienteEditarForm.invalid"> 
-            Actualizar
-        </button>
-        <button class="btn btn-primary mb-2 mr-1" type="button" [routerLink]="['/home/gestionar-cliente']"> 
-            atras
-        </button>
+            <mat-form-field appearance="fill" class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2">
+              <mat-label>Correo</mat-label>
+              <input matInput type="text" name="correo" #correo="ngModel" [(ngModel)]="service.selectCliente.correo"
+                [pattern]="correoPattern" required>
+            </mat-form-field>
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Número de documento</mat-label>
+              <input matInput type="text" name="doc" #doc="ngModel" [(ngModel)]="service.selectCliente.doc" disabled required>
+            </mat-form-field>
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Celular</mat-label>
+              <input matInput type="text" name="celular" #celular="ngModel" [(ngModel)]="service.selectCliente.celular"
+                [pattern]="celularPattern" required>
+            </mat-form-field>
+          </div>
+          <div class="form-row">
+            <mat-form-field class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12 mb-12" appearance="fill">
+              <mat-label>Dirección</mat-label>
+              <textarea matInput type="text" name="direccion" #direccion="ngModel"
+                [(ngModel)]="service.selectCliente.direccion" required></textarea>
+            </mat-form-field>
+          </div>
+        </mat-card-content>
+      </mat-card>
+      <button class="btn btn-primary mb-2 mr-1" type="submit" [disabled]="clienteEditarForm.invalid">
+        Actualizar
+      </button>
+      <button class="btn btn-primary mb-2 mr-1" type="button" [routerLink]="['/home/gestionar-cliente']">
+        atras
+      </button>
     </form>
+  </div>
 </div>

--- a/src/app/control-panel/gestionar-cliente/editar-cliente/editar-cliente.component.ts
+++ b/src/app/control-panel/gestionar-cliente/editar-cliente/editar-cliente.component.ts
@@ -1,15 +1,12 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { NgForm } from '@angular/forms';
 import { ClienteService } from '../service/cliente.service';
-import { FormGroup, NgForm, NgModel } from '@angular/forms';
-import { MatTableDataSource } from '@angular/material/table';
-import { Cliente } from '../model/cliente.model';
-import { DateAdapter } from '@angular/material/core';
 import swal from 'sweetalert2';
 
 @Component({
   selector: 'app-editar-cliente',
   templateUrl: './editar-cliente.component.html',
-  styleUrls: ['./editar-cliente.component.css']
+  styleUrls: ['./editar-cliente.component.css', '../clientes-common.css']
 })
 export class EditarClienteComponent implements OnInit {
 
@@ -60,11 +57,5 @@ export class EditarClienteComponent implements OnInit {
         });
       }
     );
-  }
-
-
-
-  clear(ClienteForm: NgForm) {
-    ClienteForm.reset();
   }
 }

--- a/src/app/control-panel/gestionar-cliente/gestionar-cliente.component.css
+++ b/src/app/control-panel/gestionar-cliente/gestionar-cliente.component.css
@@ -1,16 +1,7 @@
-.table{
-    width: 100%;
-  }
-
-h1{
-    font-size: 40px;
+.table {
+  width: 100%;
 }
 
-.border-gray{
-  color:gray;
-}
-
-.button-margin{
-  margin-bottom: 20px;
-  float: right;
+.border-gray {
+  color: gray;
 }

--- a/src/app/control-panel/gestionar-cliente/gestionar-cliente.component.ts
+++ b/src/app/control-panel/gestionar-cliente/gestionar-cliente.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
@@ -7,7 +7,7 @@ import { ClienteService } from './service/cliente.service';
 @Component({
   selector: 'app-gestionar-cliente',
   templateUrl: './gestionar-cliente.component.html',
-  styleUrls: ['./gestionar-cliente.component.css']
+  styleUrls: ['./gestionar-cliente.component.css', './clientes-common.css']
 })
 export class GestionarClienteComponent implements OnInit {
 

--- a/src/app/control-panel/gestionar-cliente/registrar-cliente/registrar-cliente.component.html
+++ b/src/app/control-panel/gestionar-cliente/registrar-cliente/registrar-cliente.component.html
@@ -1,101 +1,86 @@
-<div class="container-fluid dashboard-content ">
-    <div class="row">
-        <div class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12">
-            <div class="page-header">
-                <h2 class="pageheader-title">Form Validations </h2>
-                <p class="pageheader-text">Proin placerat ante duiullam scelerisque a velit ac porta, fusce sit amet vestibulum mi. Morbi lobortis pulvinar quam.</p>
-                <div class="page-breadcrumb">
-                    <nav aria-label="breadcrumb">
-                        <ol class="breadcrumb">
-                            <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Dashboard</a></li>
-                            <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Forms</a></li>
-                            <li class="breadcrumb-item active" aria-current="page">Form Validations</li>
-                        </ol>
-                    </nav>
-                </div>
-            </div>
-        </div>
-    </div>
+<div class="dashboard-ecommerce">
+  <div class="container-fluid dashboard-content">
+    <h1 class="mb-4">Clientes</h1>
 
     <form #clienteForm="ngForm" (ngSubmit)="addCliente(clienteForm)">
-        <!-- card numero 1 -->
-        <mat-card class="card">
-            <mat-card-header class="card-header">
-                <mat-card-title>Registrar Cliente</mat-card-title>
-            </mat-card-header>
-            <mat-card-content class="card-body">
-                <div class="form-row">
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Nombre</mat-label>
-                        <input matInput type="text" name="nombre" #nombre="ngModel" ngModel [pattern]="nombrePattern" required>
-                        <div *ngIf="nombre.errors?.pattern">
-                            <p>*Sólo letras</p>
-                        </div>
-                        <div *ngIf="nombre.errors?.required">
-                            <p>*Campo Requerido</p>
-                        </div>
-                    </mat-form-field>
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Apellido</mat-label>
-                        <input matInput type="text" name="apellido" #apellido="ngModel" ngModel [pattern]="apellidoPattern" required>
-                        <div *ngIf="apellido.errors?.pattern">
-                            <p>*Sólo letras</p>
-                        </div>
-                        <div *ngIf="apellido.errors?.required">
-                            <p>*Campo Requerido</p>
-                        </div>
-                    </mat-form-field>
+      <mat-card class="card">
+        <mat-card-header class="card-header">
+          <mat-card-title>Registrar Cliente</mat-card-title>
+        </mat-card-header>
+        <mat-card-content class="card-body">
+          <div class="form-row">
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Nombre</mat-label>
+              <input matInput type="text" name="nombre" #nombre="ngModel" ngModel [pattern]="nombrePattern" required>
+              <div *ngIf="nombre.errors?.pattern">
+                <p>*Sólo letras</p>
+              </div>
+              <div *ngIf="nombre.errors?.required">
+                <p>*Campo Requerido</p>
+              </div>
+            </mat-form-field>
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Apellido</mat-label>
+              <input matInput type="text" name="apellido" #apellido="ngModel" ngModel [pattern]="apellidoPattern" required>
+              <div *ngIf="apellido.errors?.pattern">
+                <p>*Sólo letras</p>
+              </div>
+              <div *ngIf="apellido.errors?.required">
+                <p>*Campo Requerido</p>
+              </div>
+            </mat-form-field>
 
-                    <mat-form-field appearance="fill" class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2">
-                        <mat-label>Correo</mat-label>
-                        <input matInput type="text" name="correo" #correo="ngModel" ngModel [pattern]="correoPattern" required>
-                        <div *ngIf="correo.errors?.pattern">
-                            <p>*Ingrese un email correcto</p>
-                        </div>
-                        <div *ngIf="correo.errors?.required">
-                            <p>*Campo Requerido</p>
-                        </div>
-                    </mat-form-field>
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Número de documento</mat-label>
-                        <input matInput type="text" name="doc" #doc="ngModel" ngModel [pattern]="docPattern" required>
-                        <div *ngIf="doc.errors?.pattern">
-                            <p>*Sólo números</p>
-                        </div>
-                        <div *ngIf="doc.errors?.required">
-                            <p>*Campo Requerido</p>
-                        </div>
-                    </mat-form-field>
-                    <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2 " appearance="fill">
-                        <mat-label>Celular</mat-label>
-                        <input matInput type="text" name="celular" #celular="ngModel" ngModel [pattern]="celularPattern" required>
-                        <div *ngIf="celular.errors?.pattern">
-                            <p>*Sólo números</p>
-                        </div>
-                        <div *ngIf="celular.errors?.required">
-                            <p>*Campo Requerido</p>
-                        </div>
-                    </mat-form-field>
-                </div>
-                <div class="form-row">
-                    <mat-form-field class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12 mb-12 " appearance="fill">
-                        <mat-label>Dirección</mat-label>
-                        <textarea matInput type="text" name="direccion" #direccion="ngModel" ngModel required></textarea>
-                        <div *ngIf="direccion.errors?.pattern">
-                            <p>*Ingrese una dirección correcta</p>
-                        </div>
-                        <div *ngIf="direccion.errors?.required">
-                            <p>*Campo Requerido</p>
-                        </div>
-                    </mat-form-field>
-                </div>
-            </mat-card-content>
-        </mat-card>
-        <button class="btn btn-primary mb-2 mr-1" type="submit" [disabled]="clienteForm.invalid"> 
-            Registrar
-        </button>
-        <button class="btn btn-primary mb-2 mr-1" type="button" [routerLink]="['/home/gestionar-cliente']"> 
-            atras
-        </button>
+            <mat-form-field appearance="fill" class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2">
+              <mat-label>Correo</mat-label>
+              <input matInput type="text" name="correo" #correo="ngModel" ngModel [pattern]="correoPattern" required>
+              <div *ngIf="correo.errors?.pattern">
+                <p>*Ingrese un email correcto</p>
+              </div>
+              <div *ngIf="correo.errors?.required">
+                <p>*Campo Requerido</p>
+              </div>
+            </mat-form-field>
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Número de documento</mat-label>
+              <input matInput type="text" name="doc" #doc="ngModel" ngModel [pattern]="docPattern" required>
+              <div *ngIf="doc.errors?.pattern">
+                <p>*Sólo números</p>
+              </div>
+              <div *ngIf="doc.errors?.required">
+                <p>*Campo Requerido</p>
+              </div>
+            </mat-form-field>
+            <mat-form-field class="col-xl-4 col-lg-4 col-md-12 col-sm-12 col-12 mb-2" appearance="fill">
+              <mat-label>Celular</mat-label>
+              <input matInput type="text" name="celular" #celular="ngModel" ngModel [pattern]="celularPattern" required>
+              <div *ngIf="celular.errors?.pattern">
+                <p>*Sólo números</p>
+              </div>
+              <div *ngIf="celular.errors?.required">
+                <p>*Campo Requerido</p>
+              </div>
+            </mat-form-field>
+          </div>
+          <div class="form-row">
+            <mat-form-field class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12 mb-12" appearance="fill">
+              <mat-label>Dirección</mat-label>
+              <textarea matInput type="text" name="direccion" #direccion="ngModel" ngModel required></textarea>
+              <div *ngIf="direccion.errors?.pattern">
+                <p>*Ingrese una dirección correcta</p>
+              </div>
+              <div *ngIf="direccion.errors?.required">
+                <p>*Campo Requerido</p>
+              </div>
+            </mat-form-field>
+          </div>
+        </mat-card-content>
+      </mat-card>
+      <button class="btn btn-primary mb-2 mr-1" type="submit" [disabled]="clienteForm.invalid">
+        Registrar
+      </button>
+      <button class="btn btn-primary mb-2 mr-1" type="button" [routerLink]="['/home/gestionar-cliente']">
+        atras
+      </button>
     </form>
+  </div>
 </div>

--- a/src/app/control-panel/gestionar-cliente/registrar-cliente/registrar-cliente.component.ts
+++ b/src/app/control-panel/gestionar-cliente/registrar-cliente/registrar-cliente.component.ts
@@ -1,15 +1,12 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { NgForm } from '@angular/forms';
 import { ClienteService } from '../service/cliente.service';
-import { FormGroup, NgForm, NgModel } from '@angular/forms';
-import { MatTableDataSource } from '@angular/material/table';
-import { Cliente } from '../model/cliente.model';
-import { DateAdapter } from '@angular/material/core';
 import swal from 'sweetalert2';
 
 @Component({
   selector: 'app-registrar-cliente',
   templateUrl: './registrar-cliente.component.html',
-  styleUrls: ['./registrar-cliente.component.css']
+  styleUrls: ['./registrar-cliente.component.css', '../clientes-common.css']
 })
 export class RegistrarClienteComponent implements OnInit {
 


### PR DESCRIPTION
## Summary
- remove unused imports from the registrar and editar cliente components and drop the unused clear helper
- replace the outdated page headers in registrar/editar with the Clientes heading used in the list view and add a shared clientes-common.css
- load the shared stylesheet from all cliente screens so typography, spacing, and action buttons match

## Testing
- npm test
- CI=true npx ng serve --host 0.0.0.0 --port 4200 *(fails: missing @fullcalendar/core and daygrid CSS assets referenced from angular.json)*

------
https://chatgpt.com/codex/tasks/task_e_68daafab35fc8333be69d11ae7d4528e